### PR TITLE
Added support for Python 3.6 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ dist: bionic
 python:
   - "3.6"
   - "3.7"
-  - "3.8"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ install:
     - pip install faster-fifo
 
 script:
+  - which pip
+  - pip --version
   - coverage run -m unittest cpp_faster_fifo/tests/test_faster_fifo.py
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ notifications:
 
 install:
     - pip install -q cython
-    - pip install --upgrade pip
+    - pip install --upgrade pip>=19.3.1
     - pip install coverage
     - pip install faster-fifo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ notifications:
 
 install:
     - pip install -q cython
+    - pip install --upgrade pip
     - pip install coverage
     - pip install faster-fifo
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 language: python
 dist: bionic
 python:
+  - "3.5"
+  - "3.6"
   - "3.7"
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: bionic
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,19 @@
 language: python
 dist: bionic
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 
 notifications:
   email: false
 
 install:
     - pip install -q cython
-    - pip install --upgrade pip>=19.3.1
     - pip install coverage
     - pip install faster-fifo
 
 script:
-  - which pip
-  - pip --version
   - coverage run -m unittest cpp_faster_fifo/tests/test_faster_fifo.py
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # faster-fifo
 
-Faster alternative to Python's standard multiprocessing.Queue (IPC FIFO queue). Up to 30x faster in some configurations. (requires Python 3.6+)
+Faster alternative to Python's standard multiprocessing.Queue (IPC FIFO queue). Up to 30x faster in some configurations. (**requires Python 3.6 or 3.7**)
 
 Implemented in C++ using POSIX mutexes with PTHREAD_PROCESS_SHARED attribute. Based on a circular buffer, low footprint, brokerless.
 Completely mimics the interface of the standard multiprocessing.Queue, so can be used as a drop-in replacement.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # faster-fifo
 
-Faster alternative to Python's standard multiprocessing.Queue (IPC FIFO queue). Up to 30x faster in some configurations.
+Faster alternative to Python's standard multiprocessing.Queue (IPC FIFO queue). Up to 30x faster in some configurations. (requires Python 3.6+)
 
 Implemented in C++ using POSIX mutexes with PTHREAD_PROCESS_SHARED attribute. Based on a circular buffer, low footprint, brokerless.
 Completely mimics the interface of the standard multiprocessing.Queue, so can be used as a drop-in replacement.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # faster-fifo
 
-Faster alternative to Python's standard multiprocessing.Queue (IPC FIFO queue). Up to 30x faster in some configurations. (**requires Python 3.6 or 3.7**)
+Faster alternative to Python's standard multiprocessing.Queue (IPC FIFO queue). Up to 30x faster in some configurations. (**requires Python 3.6 or newer**)
 
 Implemented in C++ using POSIX mutexes with PTHREAD_PROCESS_SHARED attribute. Based on a circular buffer, low footprint, brokerless.
 Completely mimics the interface of the standard multiprocessing.Queue, so can be used as a drop-in replacement.

--- a/cpp_faster_fifo/tests/test_faster_fifo.py
+++ b/cpp_faster_fifo/tests/test_faster_fifo.py
@@ -121,15 +121,15 @@ class TestFastQueue(TestCase):
         self.assertFalse(q_empty)
 
     def test_queue_full(self):
-        q = Queue(max_size_bytes=500)
+        q = Queue(max_size_bytes=60)
         self.assertFalse(q.full())
-        py_obj = dict(a=42, b=33, c=(1, 2, 3), d=[1, 2, 3], e='123', f=b'kkk')
-        q.put_nowait(py_obj)
-        self.assertFalse(q.full())
-        try:
-            q.put_nowait(py_obj)
-        except Full:
-            self.assertTrue(q.full())
+        py_obj = (1, 2)
+        while True:
+            try:
+                q.put_nowait(py_obj)
+            except Full:
+                self.assertTrue(q.full())
+                break
 
     def test_queue_usage(self):
         from faster_fifo import Queue

--- a/cpp_faster_fifo/tests/test_faster_fifo.py
+++ b/cpp_faster_fifo/tests/test_faster_fifo.py
@@ -121,11 +121,15 @@ class TestFastQueue(TestCase):
         self.assertFalse(q_empty)
 
     def test_queue_full(self):
-        q = Queue(max_size_bytes=105)
+        q = Queue(max_size_bytes=500)
         self.assertFalse(q.full())
         py_obj = dict(a=42, b=33, c=(1, 2, 3), d=[1, 2, 3], e='123', f=b'kkk')
         q.put_nowait(py_obj)
-        self.assertTrue(q.full())
+        self.assertFalse(q.full())
+        try:
+            q.put_nowait(py_obj)
+        except Full:
+            self.assertTrue(q.full())
 
     def test_queue_usage(self):
         from faster_fifo import Queue

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('README.md', 'r') as fh:
 setup(
     # Information
     name='faster-fifo',
-    version='1.0.1',
+    version='1.0.2',
     url='https://github.com/alex-petrenko/faster-fifo',
     author='Aleksei Petrenko & Tushar Kumar',
     license='MIT',
@@ -30,4 +30,5 @@ setup(
     ext_modules=cythonize(extensions),
     setup_requires=['setuptools>=45.2.0', 'cython>=0.29'],
     python_requires='>=3.5, <3.8',
+    install_requires=["pip>=19.3"],
 )

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     # Build instructions
     ext_modules=cythonize(extensions),
     setup_requires=['setuptools>=45.2.0', 'cython>=0.29'],
-    python_requires='>=3.6, <3.8',
+    python_requires='>=3.6',
     install_requires=["pip>=19.3"],
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('README.md', 'r') as fh:
 setup(
     # Information
     name='faster-fifo',
-    version='1.0.3',
+    version='1.0.4',
     url='https://github.com/alex-petrenko/faster-fifo',
     author='Aleksei Petrenko & Tushar Kumar',
     license='MIT',
@@ -29,6 +29,6 @@ setup(
     # Build instructions
     ext_modules=cythonize(extensions),
     setup_requires=['setuptools>=45.2.0', 'cython>=0.29'],
-    python_requires='>=3.6',
+    python_requires='>=3.6, <3.8',
     install_requires=["pip>=19.3"],
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('README.md', 'r') as fh:
 setup(
     # Information
     name='faster-fifo',
-    version='1.0.0',
+    version='1.0.1',
     url='https://github.com/alex-petrenko/faster-fifo',
     author='Aleksei Petrenko & Tushar Kumar',
     license='MIT',
@@ -29,5 +29,5 @@ setup(
     # Build instructions
     ext_modules=cythonize(extensions),
     setup_requires=['setuptools>=45.2.0', 'cython>=0.29'],
-    python_requires='>=3.7',
+    python_requires='>=3.5, <3.8',
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open('README.md', 'r') as fh:
 setup(
     # Information
     name='faster-fifo',
-    version='1.0.2',
+    version='1.0.3',
     url='https://github.com/alex-petrenko/faster-fifo',
     author='Aleksei Petrenko & Tushar Kumar',
     license='MIT',
@@ -29,6 +29,6 @@ setup(
     # Build instructions
     ext_modules=cythonize(extensions),
     setup_requires=['setuptools>=45.2.0', 'cython>=0.29'],
-    python_requires='>=3.5, <3.8',
+    python_requires='>=3.6',
     install_requires=["pip>=19.3"],
 )


### PR DESCRIPTION
Tried adding support for 3.5 and 3.8, but 3.5 had some issue with ForkingPickler and in 3.8 the q.full() test case was failing. So for now, Python 3.6 has been integrated and tested and a build has been deployed on pip. Current version stands at 1.0.4 because of multiple tests I was doing.