### PR TITLE
Switch compile args to c++11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ extensions = [
         name='faster_fifo',
         sources=['faster_fifo.pyx', 'cpp_faster_fifo/cpp_lib/faster_fifo.cpp'],
         language='c++',
-        extra_compile_args=['-std=c++14'],
+        extra_compile_args=['-std=c++11'],
         include_dirs=['cpp_faster_fifo/cpp_lib'],
     ),
 ]


### PR DESCRIPTION
From https://github.com/alex-petrenko/faster-fifo/issues/25

This is all I had to change to get the extension to build on CentOS 7.
