### PR TITLE
Add method `Queue.data_size`

### DIFF
--- a/cpp_faster_fifo/cpp_lib/faster_fifo.cpp
+++ b/cpp_faster_fifo/cpp_lib/faster_fifo.cpp
@@ -273,6 +273,11 @@ size_t get_queue_size(void *queue_obj) {
     return q->num_elem;
 }
 
+size_t get_data_size(void *queue_obj) {
+    auto q = (Queue *)queue_obj;
+    return q->size;
+}
+
 bool is_queue_full(void *queue_obj) {
     auto q = (Queue *)queue_obj;
     constexpr size_t min_message_size = 1;

--- a/cpp_faster_fifo/cpp_lib/faster_fifo.hpp
+++ b/cpp_faster_fifo/cpp_lib/faster_fifo.hpp
@@ -20,4 +20,6 @@ int queue_get(void *queue_obj, void *buffer,
 
 size_t get_queue_size(void *queue_obj);
 
+size_t get_data_size(void *queue_obj);
+
 bool is_queue_full(void *queue_obj);

--- a/cpp_faster_fifo/tests/test_faster_fifo.py
+++ b/cpp_faster_fifo/tests/test_faster_fifo.py
@@ -171,6 +171,15 @@ class TestFastQueue(TestCase):
         q_empty = q.empty()
         self.assertFalse(q_empty)
 
+    def test_queue_data_size(self):
+        q = Queue(max_size_bytes=1000)
+        py_obj = dict(a=10, b=20)
+        q.put_nowait(py_obj)
+        py_obj_size = q.data_size()
+        log.debug('Queue data size after put -  %d', py_obj_size)
+        q.put_nowait(py_obj)
+        self.assertTrue(q.data_size(), 2*py_obj_size)
+
     def test_queue_full(self):
         q = Queue(max_size_bytes=60)
         self.assertFalse(q.full())

--- a/faster_fifo.pyx
+++ b/faster_fifo.pyx
@@ -253,6 +253,9 @@ class Queue:
     def qsize(self):
         return Q.get_queue_size(<void *>q_addr(self))
 
+    def data_size(self):
+        return Q.get_data_size(<void *>q_addr(self))
+
     def empty(self):
         """
         Return True if the queue is empty, False otherwise. 

--- a/faster_fifo_def.pxd
+++ b/faster_fifo_def.pxd
@@ -13,4 +13,5 @@ cdef extern from 'cpp_faster_fifo/cpp_lib/faster_fifo.hpp':
                   size_t max_messages_to_get, size_t max_bytes_to_get,
                   size_t *messages_read, size_t *bytes_read, size_t *messages_size, int block, float timeout) nogil;
     size_t get_queue_size(void *queue_obj);
+    size_t get_data_size(void *queue_obj);
     bool is_queue_full(void *queue_obj);


### PR DESCRIPTION
## Description

This PR adds a new method to `Queue` class called `data_size`. This method returns the amount of shared memory used by elements inside the queue