### PR TITLE
Arch linux install - Add '#include <stdio.h>' header

### DIFF
--- a/cpp_faster_fifo/cpp_lib/faster_fifo.cpp
+++ b/cpp_faster_fifo/cpp_lib/faster_fifo.cpp
@@ -7,6 +7,8 @@
 
 #include "faster_fifo.hpp"
 
+#include <stdio.h>
+
 
 // Logs the error message to stderr and in debug mode triggers assert if the condition is false.
 #define LOG_ASSERT(cond, msg) \


### PR DESCRIPTION
Hello Alex,


I had the following error on my setup when trying to install faster-fifo (`pip install faster-fifo`):
<details>
<summary>Output</summary>

`Collecting faster-fifo
  Using cached faster-fifo-1.4.5.tar.gz (87 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: setuptools>=45.2.0 in ./venv/lib/python3.11/site-packages (from faster-fifo) (67.7.2)
Requirement already satisfied: cython>=0.29 in ./venv/lib/python3.11/site-packages (from faster-fifo) (0.29.34)
Building wheels for collected packages: faster-fifo
  Building wheel for faster-fifo (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for faster-fifo (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [111 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib.linux-x86_64-cpython-311
      creating build/lib.linux-x86_64-cpython-311/faster_fifo_reduction
      copying faster_fifo_reduction/__init__.py -> build/lib.linux-x86_64-cpython-311/faster_fifo_reduction
      creating build/lib.linux-x86_64-cpython-311/cpp_faster_fifo
      copying cpp_faster_fifo/__init__.py -> build/lib.linux-x86_64-cpython-311/cpp_faster_fifo
      creating build/lib.linux-x86_64-cpython-311/cpp_faster_fifo/tests
      copying cpp_faster_fifo/tests/test_faster_fifo.py -> build/lib.linux-x86_64-cpython-311/cpp_faster_fifo/tests
      copying cpp_faster_fifo/tests/comparison_tests.py -> build/lib.linux-x86_64-cpython-311/cpp_faster_fifo/tests
      copying cpp_faster_fifo/tests/__init__.py -> build/lib.linux-x86_64-cpython-311/cpp_faster_fifo/tests
      running build_ext
      building 'faster_fifo' extension
      creating build/temp.linux-x86_64-cpython-311
      creating build/temp.linux-x86_64-cpython-311/cpp_faster_fifo
      creating build/temp.linux-x86_64-cpython-311/cpp_faster_fifo/cpp_lib
      gcc -DNDEBUG -g -fwrapv -O3 -Wall -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -ffat-lto-objects -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -march=x86-64 -mtune=generic -O3 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -g -ffile-prefix-map=/build/python/src=/usr/src/debug/python -flto=auto -fPIC -I. -Icpp_faster_fifo/cpp_lib -I/home/loop/PycharmProjects/smart_assistant/venv/include -I/usr/include/python3.11 -c cpp_faster_fifo/cpp_lib/faster_fifo.cpp -o build/temp.linux-x86_64-cpython-311/cpp_faster_fifo/cpp_lib/faster_fifo.o -std=c++11
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp: In member function ‘void Queue::circular_buffer_write(uint8_t*, const uint8_t*, size_t)’:
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: ‘stderr’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |                 ^~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:58:9: note: in expansion of macro ‘LOG_ASSERT’
         58 |         LOG_ASSERT(size <= max_size_bytes, "Combined message size exceeds the size of the queue");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:9:1: note: ‘stderr’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
          8 | #include "faster_fifo.hpp"
        +++ |+#include <cstdio>
          9 |
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: ‘fprintf’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |         ^~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:58:9: note: in expansion of macro ‘LOG_ASSERT’
         58 |         LOG_ASSERT(size <= max_size_bytes, "Combined message size exceeds the size of the queue");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: ‘stderr’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |                 ^~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:59:9: note: in expansion of macro ‘LOG_ASSERT’
         59 |         LOG_ASSERT(tail < max_size_bytes, "Tail pointer points past the buffer boundary");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: note: ‘stderr’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |                 ^~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:59:9: note: in expansion of macro ‘LOG_ASSERT’
         59 |         LOG_ASSERT(tail < max_size_bytes, "Tail pointer points past the buffer boundary");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: ‘fprintf’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |         ^~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:59:9: note: in expansion of macro ‘LOG_ASSERT’
         59 |         LOG_ASSERT(tail < max_size_bytes, "Tail pointer points past the buffer boundary");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp: In member function ‘void Queue::circular_buffer_read(uint8_t*, uint8_t*, size_t, bool)’:
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: ‘stderr’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |                 ^~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:78:9: note: in expansion of macro ‘LOG_ASSERT’
         78 |         LOG_ASSERT(new_head < max_size_bytes, "Circular buffer head pointer is incorrect");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: note: ‘stderr’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |                 ^~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:78:9: note: in expansion of macro ‘LOG_ASSERT’
         78 |         LOG_ASSERT(new_head < max_size_bytes, "Circular buffer head pointer is incorrect");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: ‘fprintf’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |         ^~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:78:9: note: in expansion of macro ‘LOG_ASSERT’
         78 |         LOG_ASSERT(new_head < max_size_bytes, "Circular buffer head pointer is incorrect");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: ‘stderr’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |                 ^~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:79:9: note: in expansion of macro ‘LOG_ASSERT’
         79 |         LOG_ASSERT(new_size >= 0 && new_size < max_size_bytes, "New size is incorrect after reading from buffer");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: note: ‘stderr’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |                 ^~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:79:9: note: in expansion of macro ‘LOG_ASSERT’
         79 |         LOG_ASSERT(new_size >= 0 && new_size < max_size_bytes, "New size is incorrect after reading from buffer");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: ‘fprintf’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |         ^~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:79:9: note: in expansion of macro ‘LOG_ASSERT’
         79 |         LOG_ASSERT(new_size >= 0 && new_size < max_size_bytes, "New size is incorrect after reading from buffer");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp: In function ‘int queue_get(void*, void*, void*, size_t, size_t, size_t, size_t*, size_t*, size_t*, int, float)’:
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: ‘stderr’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |                 ^~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:239:9: note: in expansion of macro ‘LOG_ASSERT’
        239 |         LOG_ASSERT(q->size >= sizeof(msg_size) + msg_size, "Queue size is less than message size!");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: note: ‘stderr’ is defined in header ‘<cstdio>’; did you forget to ‘#include <cstdio>’?
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |                 ^~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:239:9: note: in expansion of macro ‘LOG_ASSERT’
        239 |         LOG_ASSERT(q->size >= sizeof(msg_size) + msg_size, "Queue size is less than message size!");
            |         ^~~~~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: ‘fprintf’ was not declared in this scope
         14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
            |         ^~~~~~~
      cpp_faster_fifo/cpp_lib/faster_fifo.cpp:239:9: note: in expansion of macro ‘LOG_ASSERT’
        239 |         LOG_ASSERT(q->size >= sizeof(msg_size) + msg_size, "Queue size is less than message size!");
            |         ^~~~~~~~~~
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for faster-fifo
Failed to build faster-fifo
ERROR: Could not build wheels for faster-fifo, which is required to install pyproject.toml-based projects`
</details>

Setup `Arch Linux 6.3.1-arch2-1` `gcc 13.1.1 20230429 (GCC)` `Python 3.11.3` `pip 23.1.2`

To fix it, I've just added a header as it seemed obvious from the error output and quick google search - but I'm not an "expert" and do not know if this could adversely affect other kinds of setups.

Let me know if you want me to provide additional information.

<br>

Best regards,
Luka