### PR TITLE
fix: include cstdio to solve stderr not declared

### DIFF
--- a/cpp_faster_fifo/cpp_lib/faster_fifo.cpp
+++ b/cpp_faster_fifo/cpp_lib/faster_fifo.cpp
@@ -1,6 +1,7 @@
 #include <mutex>
 #include <cassert>
 #include <cstring>
+#include <cstdio>
 
 #include <pthread.h>
 #include <sys/time.h>


### PR DESCRIPTION
If you make pip installation with a gcc 13 program, the compilation crash.
```terminal
cpp_faster_fifo/cpp_lib/faster_fifo.cpp: In member function 'void Queue::circular_buffer_write(uint8_t*, const uint8_t*, size_t)':
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: 'stderr' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |                 ^~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:58:9: note: in expansion of macro 'LOG_ASSERT'
   58 |         LOG_ASSERT(size <= max_size_bytes, "Combined message size exceeds the size of the queue");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:9:1: note: 'stderr' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
    8 | #include "faster_fifo.hpp"
  +++ |+#include <cstdio>
    9 |
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: 'fprintf' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |         ^~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:58:9: note: in expansion of macro 'LOG_ASSERT'
   58 |         LOG_ASSERT(size <= max_size_bytes, "Combined message size exceeds the size of the queue");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: 'stderr' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |                 ^~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:59:9: note: in expansion of macro 'LOG_ASSERT'
   59 |         LOG_ASSERT(tail < max_size_bytes, "Tail pointer points past the buffer boundary");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: note: 'stderr' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |                 ^~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:59:9: note: in expansion of macro 'LOG_ASSERT'
   59 |         LOG_ASSERT(tail < max_size_bytes, "Tail pointer points past the buffer boundary");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: 'fprintf' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |         ^~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:59:9: note: in expansion of macro 'LOG_ASSERT'
   59 |         LOG_ASSERT(tail < max_size_bytes, "Tail pointer points past the buffer boundary");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp: In member function 'void Queue::circular_buffer_read(uint8_t*, uint8_t*, size_t, bool)':
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: 'stderr' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |                 ^~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:78:9: note: in expansion of macro 'LOG_ASSERT'
   78 |         LOG_ASSERT(new_head < max_size_bytes, "Circular buffer head pointer is incorrect");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: note: 'stderr' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |                 ^~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:78:9: note: in expansion of macro 'LOG_ASSERT'
   78 |         LOG_ASSERT(new_head < max_size_bytes, "Circular buffer head pointer is incorrect");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: 'fprintf' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |         ^~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:78:9: note: in expansion of macro 'LOG_ASSERT'
   78 |         LOG_ASSERT(new_head < max_size_bytes, "Circular buffer head pointer is incorrect");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: 'stderr' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |                 ^~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:79:9: note: in expansion of macro 'LOG_ASSERT'
   79 |         LOG_ASSERT(new_size >= 0 && new_size < max_size_bytes, "New size is incorrect after reading from buffer");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: note: 'stderr' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |                 ^~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:79:9: note: in expansion of macro 'LOG_ASSERT'
   79 |         LOG_ASSERT(new_size >= 0 && new_size < max_size_bytes, "New size is incorrect after reading from buffer");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: 'fprintf' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |         ^~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:79:9: note: in expansion of macro 'LOG_ASSERT'
   79 |         LOG_ASSERT(new_size >= 0 && new_size < max_size_bytes, "New size is incorrect after reading from buffer");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp: In function 'int queue_get(void*, void*, void*, size_t, size_t, size_t, size_t*, size_t*, size_t*, int, float)':
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: error: 'stderr' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |                 ^~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:239:9: note: in expansion of macro 'LOG_ASSERT'
  239 |         LOG_ASSERT(q->size >= sizeof(msg_size) + msg_size, "Queue size is less than message size!");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:17: note: 'stderr' is defined in header '<cstdio>'; did you forget to '#include <cstdio>'?
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |                 ^~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:239:9: note: in expansion of macro 'LOG_ASSERT'
  239 |         LOG_ASSERT(q->size >= sizeof(msg_size) + msg_size, "Queue size is less than message size!");
      |         ^~~~~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:14:9: error: 'fprintf' was not declared in this scope
   14 |         fprintf(stderr, "%s:%d %s\n", __FILE__, __LINE__, (msg)); \
      |         ^~~~~~~
cpp_faster_fifo/cpp_lib/faster_fifo.cpp:239:9: note: in expansion of macro 'LOG_ASSERT'
  239 |         LOG_ASSERT(q->size >= sizeof(msg_size) + msg_size, "Queue size is less than message size!");
      |         ^~~~~~~~~~
error: command '/usr/bin/aarch64-unknown-linux-gnu-gcc' failed with exit code 1
```

To solve this, you need to include `cstdio` in `faster_fifo.cpp`
```cpp
#include <mutex>
#include <cassert>
#include <cstring>
#include <cstdio>

#include <pthread.h>
...
```
